### PR TITLE
Support python 2 print statements in SConscripts

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -11,6 +11,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
     - Whatever John Doe did.
 
+  From Thomas Berg:
+    - Fixed a regression in scons-3.0.0 where "from __future__ import print_function" was imposed
+      on the scope where SConstruct is executed, breaking existing builds using PY 2.7.
 
 RELEASE 3.0.0 - Mon, 18 Sep 2017 08:32:04 -0700
 

--- a/src/engine/SCons/Script/SConscript.py
+++ b/src/engine/SCons/Script/SConscript.py
@@ -5,8 +5,6 @@ files.
 
 """
 
-from __future__ import print_function
-
 #
 # __COPYRIGHT__
 #

--- a/test/print_statement.py
+++ b/test/print_statement.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+import sys
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+
+test.write('SConstruct', """\
+print('python 3 style statement')
+Exit(0)
+""")
+
+test.run()
+
+test.write('SConstruct', """\
+print 'python 2 style statement'
+Exit(0)
+""")
+
+if sys.version_info >= (3,0):
+    test.skip_test('Python 2 print statement test, skipping on Python 3.\n')
+else:
+    test.run()
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
This fixes a regression introduced in scons-3.0.0, where
SConscripts containing python 2 print statements would cause
syntax errors even when executing scons with python 2.7.

This ensures backward compatibility, allowing users to build
legacy code with scons-3.0.0 without having to patch it.