### PR TITLE
Fix usage on embedded Python

### DIFF
--- a/src/script/scons.py
+++ b/src/script/scons.py
@@ -65,7 +65,7 @@ Python < 3.5 is not yet supported.\n"
     sys.exit(1)
 
 
-script_dir = sys.path[0]
+script_dir = os.path.dirname(os.path.realpath(__file__))
 
 if script_dir in sys.path:
     sys.path.remove(script_dir)

--- a/src/script/sconsign.py
+++ b/src/script/sconsign.py
@@ -57,7 +57,7 @@ import sys
 # engine modules if they're in either directory.
 
 
-script_dir = sys.path[0]
+script_dir = os.path.dirname(os.path.realpath(__file__))
 
 if script_dir in sys.path:
     sys.path.remove(script_dir)


### PR DESCRIPTION
First entry in sys.path is not always the script directory. On the [embedded distribution](https://docs.python.org/3.6/using/windows.html#embedded-distribution) of Python 3, sys.path does not contain the script directory at all. Always removing the first entry will remove the path to the standard libraries.